### PR TITLE
Fix command endings processed by vic-exec

### DIFF
--- a/src/vic-exec.c
+++ b/src/vic-exec.c
@@ -35,6 +35,7 @@ uint8_t vic_exec(char *input)
 
     vic_args_s = input + end + 1;
     char *command = input + start;
+    vic_buffer_in_len = 0;
 
     uint8_t error = vic_fn_call(command);
 

--- a/src/vic-serial.c
+++ b/src/vic-serial.c
@@ -73,6 +73,7 @@ void vic_process(char input)
     if (input == (char)0x08) { /* backspace */
         vic_buffer_pop();
     } else if (input == '\n') { /* new line */
+        vic_buffer_in[vic_buffer_in_len] = '\0';
         vic_exec(vic_buffer_in);
         vic_buffer_clear();
     } else {

--- a/src/vic-stdlib.c
+++ b/src/vic-stdlib.c
@@ -9,7 +9,7 @@ void vic_set(void)
     char var_name[VIC_VAR_NAME_LEN+1] = {'\0'};
     char var_val[VIC_VAR_VAL_LEN+1] = {'\0'};
 
-    char *args_format = "%"VIC_XSTR(VIC_VAR_NAME_LEN)"s";
+    const char *args_format = "%"VIC_XSTR(VIC_VAR_NAME_LEN)"s";
     if (vic_args(args_format, var_name) != 1) {
         vic_print_err(VIC_ERR_INVALID_ARGS);
         return;
@@ -28,7 +28,7 @@ void vic_set(void)
 void vic_get(void)
 {
     char var_name[VIC_VAR_NAME_LEN+1] = {'\0'};
-    char *args_format = "%"VIC_XSTR(VIC_VAR_NAME_LEN)"s";
+    const char *args_format = "%"VIC_XSTR(VIC_VAR_NAME_LEN)"s";
 
     if (vic_args(args_format, var_name) != 1) {
         vic_print_err(VIC_ERR_INVALID_ARGS);


### PR DESCRIPTION
* End up vic_buffer_in with '\0' when '\n' is sent
* Add ability to process next inputs while previous command hasn't been
  terminated yet
* Calm compiler warnings down (define string constants as const cahr *)

Signed-off-by: vargac <simon.varga123@gmail.com>